### PR TITLE
[Feature]: Snap the card view to top or bottom automatically

### DIFF
--- a/CardViewAnimation.xcodeproj/project.pbxproj
+++ b/CardViewAnimation.xcodeproj/project.pbxproj
@@ -291,7 +291,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = P55Z59EHDR;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CardViewAnimation/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -309,7 +309,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = P55Z59EHDR;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CardViewAnimation/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/CardViewAnimation.xcodeproj/project.pbxproj
+++ b/CardViewAnimation.xcodeproj/project.pbxproj
@@ -291,7 +291,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = P55Z59EHDR;
 				INFOPLIST_FILE = CardViewAnimation/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -309,7 +309,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = P55Z59EHDR;
 				INFOPLIST_FILE = CardViewAnimation/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/CardViewAnimation/ViewController.swift
+++ b/CardViewAnimation/ViewController.swift
@@ -80,7 +80,6 @@ class ViewController: UIViewController {
             fractionComplete = cardVisible ? fractionComplete : -fractionComplete
             updateInteractiveTransition(fractionCompleted: fractionComplete)
         case .ended:
-            
             //Here, check where to snap the card view as velocity and position
             //of card view (while drag) changes.
             //velocityFactor decides how much velocity contributes in the
@@ -97,11 +96,11 @@ class ViewController: UIViewController {
             } else {
                 //Reverse animation direction
                 for animator in runningAnimations {
-                    animator.stopAnimation(true)
+                    animator.isReversed = true
                 }
-                runningAnimations.removeAll()
+                //Change card state to cancel out the one in the completion block.
                 cardVisible = !cardVisible
-                animateTransitionIfNeeded(state: nextState, duration: 0.9)
+                continueInteractiveTransition()
             }
 
         default:


### PR DESCRIPTION
Depending on the velocity of the pan gesture and to what extent the card has been dragged, the card view is snapped to the top or bottom of the screen. If you dragged the handler fast enough, the card goes in the direction of the velocity. Also, if you dragged the card view far enough, it will snap to the closest side, whether it is top or bottom.